### PR TITLE
Build the MSVC dll with C cleanup code

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -11,6 +11,10 @@ copy pthread.h %LIBRARY_INC%\pthread.h
 copy sched.h %LIBRARY_INC%\sched.h
 copy semaphore.h %LIBRARY_INC%\semaphore.h
 
+nmake /E clean VC
+copy pthreadVC2.lib %LIBRARY_LIB%\pthreadVC2.lib
+copy pthreadVC2.dll %LIBRARY_BIN%\pthreadVC2.dll
+
 nmake /E clean VC-static
 copy pthreadVC2.lib %LIBRARY_LIB%\pthreads_static.lib
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -17,6 +17,7 @@ copy pthreadVC2.dll %LIBRARY_BIN%\pthreadVC2.dll
 
 nmake /E clean VC-static
 copy pthreadVC2.lib %LIBRARY_LIB%\pthreads_static.lib
+copy pthreadVC2.lib %LIBRARY_LIB%\pthreadVC2-s.lib
 
 cd tests
 set "CFLAGS=%XCFLAGS%"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ test:
     - if not exist %LIBRARY_LIB%\pthread.lib exit 1
     - if not exist %LIBRARY_LIB%\pthreadVC2.lib exit 1
     - if not exist %LIBRARY_LIB%\pthreads_static.lib exit 1
+    - if not exist %LIBRARY_LIB%\pthreadVC2-s.lib exit 1
 
 about:
   home: https://www.sourceware.org/pthreads-win32/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,10 @@ test:
   commands:
     - if not exist %LIBRARY_INC%\pthread.h exit 1
     - if not exist %LIBRARY_BIN%\pthreadVSE2.dll exit 1
+    - if not exist %LIBRARY_BIN%\pthreadVC2.dll exit 1
     - if not exist %LIBRARY_LIB%\pthreads.lib exit 1
     - if not exist %LIBRARY_LIB%\pthread.lib exit 1
+    - if not exist %LIBRARY_LIB%\pthreadVC2.lib exit 1
     - if not exist %LIBRARY_LIB%\pthreads_static.lib exit 1
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - macro_redefined.patch
 
 build:
-  number: 3
+  number: 4
   skip: True   # [not win]
 
 requirements:


### PR DESCRIPTION
Checklist
* [X] Used a fork of the feedstock to propose changes
* [X] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

I'd like to package `cppTango` with Conda that depends on `pthreads-win32`. It relies on (see [CMakeLists.txt](https://github.com/tango-controls/cppTango/blob/fe934f0ccf09980e679e1f87b0bd042573a31a9b/configure/CMakeLists.txt#L124)):
```
        set(PTHREAD_WIN_PKG_LIBRARIES_DYN "pthreadVC2.lib")
        set(PTHREAD_WIN_PKG_LIBRARIES_STA "pthreadVC2-s.lib")
```

I added the `pthreadVC2` lib and dll to the package.
I also added the `pthreadVC2-s.lib` name for the static lib. Is it possible to create a link instead?